### PR TITLE
Update __init__.py

### DIFF
--- a/modules/base_plugins/one_wire/__init__.py
+++ b/modules/base_plugins/one_wire/__init__.py
@@ -52,7 +52,7 @@ class myThread (threading.Thread):
                 ## Test Mode
                 if self.sensor_name is None:
                     return
-                with open('/sys/bus/w1/devices/w1_bus_master1/%s/w1_slave' % self.sensor_name, 'r') as content_file:
+                with open('/sys/bus/w1/devices/%s/w1_slave' % self.sensor_name, 'r') as content_file:
                     content = content_file.read()
                     if (content.split('\n')[0].split(' ')[11] == "YES"):
                         temp = float(content.split("=")[-1]) / 1000  # temp in Celcius


### PR DESCRIPTION
Remove reference to w1_bus_master1 since sensors could be no several bus masters like
```
# CraftBeerPi 1-wire support
dtoverlay=w1-gpio,gpiopin=4
dtoverlay=w1-gpio,gpiopin=27
dtoverlay=w1-gpio,gpiopin=18

```
Also polling time need to be configurable ( general parameter may be ).
Reading each sensor takes 0.8 sec, so 5 sec only allows 6 sensors.